### PR TITLE
Add Network Policy and Role/RoleBinding

### DIFF
--- a/.github/workflows/chart-version.yaml
+++ b/.github/workflows/chart-version.yaml
@@ -1,9 +1,7 @@
 name: Chart Version Test
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   # JOB to run change detection

--- a/.github/workflows/chart-version.yaml
+++ b/.github/workflows/chart-version.yaml
@@ -1,0 +1,100 @@
+name: Chart Version Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  # JOB to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    outputs:
+      # Expose matched filters as job 'charts' output variable
+      charts: ${{ steps.filter.outputs.changes }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          docreader: charts/docreader/*
+          faceapi: charts/faceapi/*
+
+  chart-version:
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJSON(needs.changes.outputs.charts) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Get old chart version
+        id: old_version
+        shell: bash
+        run: |
+          old_version=$(grep -m1 version\: charts/${{ matrix.chart }}/Chart.yaml | awk -F ' ' '{print $2}')
+          echo "old_version=$old_version" >> $GITHUB_OUTPUT
+
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+
+      - name: Get new chart version and compare
+        id: new_version
+        shell: bash
+        run: |
+          new_version=$(grep -m1 version\: charts/${{ matrix.chart }}/Chart.yaml | awk -F ' ' '{print $2}')
+          old_version=${{ steps.old_version.outputs.old_version }}
+          echo "new_version = $new_version"
+          echo "old_version = $old_version"
+
+          if [[ "$new_version" == "$old_version" ]]; then
+            echo "New and old Chart versions are equal. Please increase the Chart version"
+            exit 1
+          fi
+          
+          new_version=(${new_version//./ })
+          old_version=(${old_version//./ })
+
+          if [[ "${#new_version[@]}" -ne "${#old_version[@]}" ]]; then
+            echo "Version formats do not match"
+            exit 1
+          fi
+          
+          for i in $(seq 0 ${#new_version[@]}); do
+            case "$i" in
+              0)
+              version="Major"
+              ;;
+          
+              1)
+              version="Minor"
+              ;;
+          
+              *)
+              version="Patch"
+              ;;
+            esac
+          
+            if [[ "${new_version[$i]}" -gt "${old_version[$i]}" ]]; then
+              echo "$version version is greater than previous one"
+              echo "Version is OK"
+              break
+            elif [[ "${new_version[$i]}" -eq "${old_version[$i]}" ]]; then
+              echo "$version version is equal to previous one. Keep checking..."
+            else
+              echo "$version version is lower than previous one"
+              echo "Version is NOT OK. Please increase the Chart version"
+              exit 1
+            fi
+          done
+          
+          exit 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,3 +7,5 @@ on:
 jobs:
   call-lint-test:
     uses: ./.github/workflows/lint-test.yml
+  call-chart-version:
+    uses: ./.github/workflows/chart-version.yaml

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
           version: ${{ inputs.helm_version }}
 
@@ -44,14 +44,14 @@ jobs:
         run: |
           changed=$(ct list-changed --config "${CT_CONFIGFILE}")
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
         run: ct lint --config "${CT_CONFIGFILE}" --validate-maintainers=false
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1.10.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
-version: 1.1.4
+version: 1.2.0
 appVersion: nightly
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/docreader/README.md
+++ b/charts/docreader/README.md
@@ -162,7 +162,14 @@ A major chart version change (like v0.1.2 -> v1.0.0) indicates that there is an 
 | `livenessProbe.enabled`                   | Enable livenessProbe                                                                          | `true`                        |
 | `readinessProbe.enabled`                  | Enable readinessProbe                                                                         | `true`                        |
 | `autoscaling.enabled`                     | Enable autoscaling                                                                            | `false`                       |
-
+| `networkPolicy.enabled`                   | Enable NetworkPolicy                                                                          | `false`                       |
+| `networkPolicy.annotations`               | NetworkPolicy annotations                                                                     | `{}`                          |
+| `networkPolicy.ingress`                   | Set NetworkPolicy Ingress rules                                                               | `{}`                          |
+| `networkPolicy.egress`                    | Set NetworkPolicy Egress rules                                                                | `{}`                          |
+| `rbac.create`                             | Create Role and RoleBinding                                                                   | `false`                       |
+| `rbac.annotations`                        | Role and RoleBinding annotations                                                              | `{}`                          |
+| `rbac.useExistingRole`                    | Existing Role name to use                                                                     | `""`                          |
+| `rbac.extraRoleRules`                     | Extra rules for Role                                                                          | `[]`                          |
 
 ## Application parameters
 

--- a/charts/docreader/templates/_helpers.tpl
+++ b/charts/docreader/templates/_helpers.tpl
@@ -45,7 +45,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* Create the name of the service account to use */}}
 {{- define "docreader.serviceAccount" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default "docreader" .Values.serviceAccount.name }}
+    {{ default (include "docreader.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/charts/docreader/templates/networkpolicy.yaml
+++ b/charts/docreader/templates/networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "docreader.fullname" . }}
+  labels:
+    {{- include "docreader.labels" . | nindent 4 }}
+  {{- with .Values.networkPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  policyTypes:
+    {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  podSelector:
+    matchLabels:
+      {{- include "docreader.selectorLabels" . | nindent 6 }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if not .Values.networkPolicy.egress.blockDNSResolution }}
+    - ports:
+        - port: 53
+          protocol: UDP
+    {{- end }}
+    - ports:
+        {{ .Values.networkPolicy.egress.ports | toJson }}
+      {{- with .Values.networkPolicy.egress.to }}
+      to:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    - ports:
+      - port: docreader
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ include "docreader.fullname" . }}-client: "true"
+        {{- with .Values.networkPolicy.explicitNamespacesSelector }}
+        - namespaceSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        - podSelector:
+            matchLabels:
+              {{- include "docreader.selectorLabels" . | nindent 14 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/docreader/templates/networkpolicy.yaml
+++ b/charts/docreader/templates/networkpolicy.yaml
@@ -14,42 +14,17 @@ spec:
     {{- if .Values.networkPolicy.ingress }}
     - Ingress
     {{- end }}
-    {{- if .Values.networkPolicy.egress.enabled }}
+    {{- if .Values.networkPolicy.egress }}
     - Egress
     {{- end }}
   podSelector:
     matchLabels:
-      {{- include "docreader.selectorLabels" . | nindent 6 }}
-  {{- if .Values.networkPolicy.egress.enabled }}
-  egress:
-    {{- if not .Values.networkPolicy.egress.blockDNSResolution }}
-    - ports:
-        - port: 53
-          protocol: UDP
-    {{- end }}
-    - ports:
-        {{ .Values.networkPolicy.egress.ports | toJson }}
-      {{- with .Values.networkPolicy.egress.to }}
-      to:
-        {{- toYaml . | nindent 12 }}
-      {{- end }}
-  {{- end }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.networkPolicy.ingress }}
-  ingress:
-    - ports:
-      - port: docreader
-      {{- if not .Values.networkPolicy.allowExternal }}
-      from:
-        - podSelector:
-            matchLabels:
-              {{ include "docreader.fullname" . }}-client: "true"
-        {{- with .Values.networkPolicy.explicitNamespacesSelector }}
-        - namespaceSelector:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
-        - podSelector:
-            matchLabels:
-              {{- include "docreader.selectorLabels" . | nindent 14 }}
-      {{- end }}
-  {{- end }}
+  ingress: {{- toYaml .Values.networkPolicy.ingress | nindent 4 -}}
+  {{- end -}}
+  {{- if .Values.networkPolicy.egress }}
+  egress: {{- toYaml .Values.networkPolicy.egress | nindent 4 -}}
+  {{- end -}}
 {{- end }}

--- a/charts/docreader/templates/role.yaml
+++ b/charts/docreader/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "docreader.fullname" . }}
+  labels:
+    {{- include "docreader.labels" . | nindent 4 }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if .Values.rbac.extraRoleRules }}
+rules:
+  {{- with .Values.rbac.extraRoleRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}

--- a/charts/docreader/templates/role.yaml
+++ b/charts/docreader/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) -}}
+{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) .Values.serviceAccount.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/docreader/templates/role.yaml
+++ b/charts/docreader/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) .Values.serviceAccount.create -}}
+{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/docreader/templates/rolebinding.yaml
+++ b/charts/docreader/templates/rolebinding.yaml
@@ -19,5 +19,5 @@ roleRef:
   {{- end }}
 subjects:
 - kind: ServiceAccount
-  name: {{ default "docreader" .Values.serviceAccount.name }}
+  name: {{ include "docreader.serviceAccount" . }}
 {{- end }}

--- a/charts/docreader/templates/rolebinding.yaml
+++ b/charts/docreader/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.serviceAccount.create }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/docreader/templates/rolebinding.yaml
+++ b/charts/docreader/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.serviceAccount.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/docreader/templates/rolebinding.yaml
+++ b/charts/docreader/templates/rolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "docreader.fullname" . }}
+  labels:
+    {{- include "docreader.labels" . | nindent 4 }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  {{- if .Values.rbac.useExistingRole }}
+  name: {{ .Values.rbac.useExistingRole }}
+  {{- else }}
+  name: {{ include "docreader.fullname" . }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ default "docreader" .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/docreader/templates/serviceaccount.yaml
+++ b/charts/docreader/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default "docreader" .Values.serviceAccount.name }}
+  name: {{ include "docreader.serviceAccount" . }}
   labels: {{- include "docreader.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/docreader/templates/serviceaccount.yaml
+++ b/charts/docreader/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default (include "docreader.fullname" .) .Values.serviceAccount.name }}
+  name: {{ default "docreader" .Values.serviceAccount.name }}
   labels: {{- include "docreader.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -254,6 +254,49 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+networkPolicy:
+  # networkPolicy.enabled: Enable creation of NetworkPolicy resources.
+  enabled: true
+  # networkPolicy.annotations: Add annotations to network policy.
+  annotations: {}
+  # networkPolicy.ingress: When true enables the creation of ingress network policy.
+  ingress: true
+  # networkPolicy.allowExternal: When set to false, only pods with the correct '-client' label will have network access to docreader port defined.
+  # When true, docreader will accept connections from any source (with the correct destination port).
+  allowExternal: false
+  # networkPolicy.explicitNamespacesSelector: A Kubernetes LabelSelector to explicitly select namespaces
+  # from which traffic could be allowed. If explicitNamespacesSelector is missing or set to {},
+  # only client Pods that are in the networkPolicy's namespace and that match other criteria, the ones that have the good label, can reach the docreader.
+  # But sometimes, we want the docreader to be accessible to clients from other namespaces, in this case, we can use this
+  # LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  #
+  # Example:
+  # explicitNamespacesSelector:
+  #   matchLabels:
+  #     role: frontend
+  #   matchExpressions:
+  #    - {key: role, operator: In, values: [frontend]}
+  #
+  explicitNamespacesSelector: {}
+  #
+  egress:
+    # networkPolicy.egress.enabled: When enabled, an egress network policy will be
+    # created allowing docreader to connect to external data sources from kubernetes cluster.
+    enabled: false
+    # networkPolicy.egress.blockDNSResolution: When enabled, DNS resolution will be blocked
+    # for all pods in the docreader namespace.
+    blockDNSResolution: false
+    # networkPolicy.egress.ports: Add individual ports to be allowed by the egress
+    # Add ports to the egress by specifying - port: <port number>
+    # Example
+    # - port: 80
+    # - port: 443
+    #
+    ports:
+    # networkPolicy.egress.to: Allow egress traffic to specific destinations
+    to: []
+    #
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -261,7 +261,7 @@ networkPolicy:
   annotations: {}
   # networkPolicy.ingress: When true enables the creation of ingress network policy.
   ingress: true
-  # networkPolicy.allowExternal: When set to false, only pods with the correct '-client' label will have network access to docreader port defined.
+  # networkPolicy.allowExternal: When set to false, only pods with the correct '-client' label within docreader namespace will have network access to docreader port defined.
   # When true, docreader will accept connections from any source (with the correct destination port).
   allowExternal: false
   # networkPolicy.explicitNamespacesSelector: A Kubernetes LabelSelector to explicitly select namespaces
@@ -295,7 +295,7 @@ networkPolicy:
     # - port: 80
     # - port: 443
     #
-    ports:
+    ports: []
     # networkPolicy.egress.to: Allow egress traffic to specific destinations
     to: []
     #

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -277,10 +277,7 @@ networkPolicy:
   #   matchExpressions:
   #    - {key: role, operator: In, values: [frontend]}
   #
-  # Allow traffic from kube-system namespace (ingress controller)
-  explicitNamespacesSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: kube-system
+  explicitNamespacesSelector: {}
   #
   egress:
     # networkPolicy.egress.enabled: When enabled, an egress network policy will be

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -299,11 +299,21 @@ networkPolicy:
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # The name of the service account to use.
   name: ~
   # Annotations to add to the service account
   annotations: {}
+
+rbac:
+  create: true
+  annotations: {}
+  # Use an existing Role
+  # useExistingRole: name-of-some-role
+  extraRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   verbs: []
 
 serviceMonitor:
   # Set this to `true` to create ServiceMonitor for Prometheus operator

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -299,14 +299,14 @@ networkPolicy:
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # The name of the service account to use.
   name: ~
   # Annotations to add to the service account
   annotations: {}
 
 rbac:
-  create: true
+  create: false
   annotations: {}
   # Use an existing Role
   # useExistingRole: name-of-some-role

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -277,7 +277,10 @@ networkPolicy:
   #   matchExpressions:
   #    - {key: role, operator: In, values: [frontend]}
   #
-  explicitNamespacesSelector: {}
+  # Allow traffic from kube-system namespace (ingress controller)
+  explicitNamespacesSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: kube-system
   #
   egress:
     # networkPolicy.egress.enabled: When enabled, an egress network policy will be

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -255,52 +255,40 @@ ingress:
   #      - chart-example.local
 
 networkPolicy:
-  # networkPolicy.enabled: Enable creation of NetworkPolicy resources.
-  enabled: true
-  # networkPolicy.annotations: Add annotations to network policy.
+  enabled: false
   annotations: {}
-  # networkPolicy.ingress: When true enables the creation of ingress network policy.
-  ingress: true
-  # networkPolicy.allowExternal: When set to false, only pods with the correct '-client' label within docreader namespace will have network access to docreader port defined.
-  # When true, docreader will accept connections from any source (with the correct destination port).
-  allowExternal: false
-  # networkPolicy.explicitNamespacesSelector: A Kubernetes LabelSelector to explicitly select namespaces
-  # from which traffic could be allowed. If explicitNamespacesSelector is missing or set to {},
-  # only client Pods that are in the networkPolicy's namespace and that match other criteria, the ones that have the good label, can reach the docreader.
-  # But sometimes, we want the docreader to be accessible to clients from other namespaces, in this case, we can use this
-  # LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
-  #
-  # Example:
-  # explicitNamespacesSelector:
-  #   matchLabels:
-  #     role: frontend
-  #   matchExpressions:
-  #    - {key: role, operator: In, values: [frontend]}
-  #
-  explicitNamespacesSelector: {}
-  #
-  egress:
-    # networkPolicy.egress.enabled: When enabled, an egress network policy will be
-    # created allowing docreader to connect to external data sources from kubernetes cluster.
-    enabled: false
-    # networkPolicy.egress.blockDNSResolution: When enabled, DNS resolution will be blocked
-    # for all pods in the docreader namespace.
-    blockDNSResolution: false
-    # networkPolicy.egress.ports: Add individual ports to be allowed by the egress
-    # Add ports to the egress by specifying - port: <port number>
-    # Example
-    # - port: 80
-    # - port: 443
-    #
-    ports: []
-    # networkPolicy.egress.to: Allow egress traffic to specific destinations
-    to: []
-    #
+  ingress: {}
+    # # allow ingress traffic from local namespace only
+    # - from:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         kubernetes.io/metadata.name: put-your-namespace-here
+  egress: {}
+    # # allow egress traffic to local namespace only
+    # - to:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         kubernetes.io/metadata.name: put-your-namespace-here
+    # # allow DNS resolution
+    # - ports:
+    #   - protocol: UDP
+    #     port: 53
+    # # allow traffic to lic.regulaforensics.com and lic2.regulaforensics.com
+    # - ports:
+    #   - protocol: TCP
+    #     port: 443
+    #   to:
+    #     - ipBlock:
+    #         cidr: 3.33.212.24/32
+    #     - ipBlock:
+    #         cidr: 15.197.254.180/32
+    #     - ipBlock:
+    #         cidr: 34.96.77.73/32
 
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
-  # The name of the service account to use.
+  # The name of service account to create.
   name: ~
   # Annotations to add to the service account
   annotations: {}

--- a/charts/faceapi/Chart.yaml
+++ b/charts/faceapi/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v2
 name: faceapi
 home: https://faceapi.regulaforensics.com/
-version: 1.4.0
+version: 1.5.0
 appVersion: nightly
 description: Face Recognition Service. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/faceapi/README.md
+++ b/charts/faceapi/README.md
@@ -136,7 +136,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | `livenessProbe.enabled`               | Enable livenessProbe                                                                          | `true`                        |
 | `readinessProbe.enabled`              | Enable readinessProbe                                                                         | `true`                        |
 | `autoscaling.enabled`                 | Enable autoscaling                                                                            | `false`                       |
-
+| `networkPolicy.enabled`               | Enable NetworkPolicy                                                                          | `false`                       |
+| `networkPolicy.annotations`           | NetworkPolicy annotations                                                                     | `{}`                          |
+| `networkPolicy.ingress`               | Set NetworkPolicy Ingress rules                                                               | `{}`                          |
+| `networkPolicy.egress`                | Set NetworkPolicy Egress rules                                                                | `{}`                          |
+| `rbac.create`                         | Create Role and RoleBinding                                                                   | `false`                       |
+| `rbac.annotations`                    | Role and RoleBinding annotations                                                              | `{}`                          |
+| `rbac.useExistingRole`                | Existing Role name to use                                                                     | `""`                          |
+| `rbac.extraRoleRules`                 | Extra rules for Role                                                                          | `[]`                          |
 
 ## Application parameters
 

--- a/charts/faceapi/templates/_helpers.tpl
+++ b/charts/faceapi/templates/_helpers.tpl
@@ -45,7 +45,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* Create the name of the service account to use */}}
 {{- define "faceapi.serviceAccount" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default "faceapi" .Values.serviceAccount.name }}
+    {{ default (include "faceapi.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/charts/faceapi/templates/networkpolicy.yaml
+++ b/charts/faceapi/templates/networkpolicy.yaml
@@ -14,42 +14,17 @@ spec:
     {{- if .Values.networkPolicy.ingress }}
     - Ingress
     {{- end }}
-    {{- if .Values.networkPolicy.egress.enabled }}
+    {{- if .Values.networkPolicy.egress }}
     - Egress
     {{- end }}
   podSelector:
     matchLabels:
-      {{- include "faceapi.selectorLabels" . | nindent 6 }}
-  {{- if .Values.networkPolicy.egress.enabled }}
-  egress:
-    {{- if not .Values.networkPolicy.egress.blockDNSResolution }}
-    - ports:
-        - port: 53
-          protocol: UDP
-    {{- end }}
-    - ports:
-        {{ .Values.networkPolicy.egress.ports | toJson }}
-      {{- with .Values.networkPolicy.egress.to }}
-      to:
-        {{- toYaml . | nindent 12 }}
-      {{- end }}
-  {{- end }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.networkPolicy.ingress }}
-  ingress:
-    - ports:
-      - port: faceapi
-      {{- if not .Values.networkPolicy.allowExternal }}
-      from:
-        - podSelector:
-            matchLabels:
-              {{ include "faceapi.fullname" . }}-client: "true"
-        {{- with .Values.networkPolicy.explicitNamespacesSelector }}
-        - namespaceSelector:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
-        - podSelector:
-            matchLabels:
-              {{- include "faceapi.selectorLabels" . | nindent 14 }}
-      {{- end }}
-  {{- end }}
+  ingress: {{- toYaml .Values.networkPolicy.ingress | nindent 4 -}}
+  {{- end -}}
+  {{- if .Values.networkPolicy.egress }}
+  egress: {{- toYaml .Values.networkPolicy.egress | nindent 4 -}}
+  {{- end -}}
 {{- end }}

--- a/charts/faceapi/templates/networkpolicy.yaml
+++ b/charts/faceapi/templates/networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "faceapi.fullname" . }}
+  labels:
+    {{- include "faceapi.labels" . | nindent 4 }}
+  {{- with .Values.networkPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  policyTypes:
+    {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  podSelector:
+    matchLabels:
+      {{- include "faceapi.selectorLabels" . | nindent 6 }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if not .Values.networkPolicy.egress.blockDNSResolution }}
+    - ports:
+        - port: 53
+          protocol: UDP
+    {{- end }}
+    - ports:
+        {{ .Values.networkPolicy.egress.ports | toJson }}
+      {{- with .Values.networkPolicy.egress.to }}
+      to:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    - ports:
+      - port: faceapi
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ include "faceapi.fullname" . }}-client: "true"
+        {{- with .Values.networkPolicy.explicitNamespacesSelector }}
+        - namespaceSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        - podSelector:
+            matchLabels:
+              {{- include "faceapi.selectorLabels" . | nindent 14 }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/faceapi/templates/role.yaml
+++ b/charts/faceapi/templates/role.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "faceapi.fullname" . }}
+  labels:
+    {{- include "faceapi.labels" . | nindent 4 }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if .Values.rbac.extraRoleRules }}
+rules:
+  {{- with .Values.rbac.extraRoleRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else }}
+rules: []
+{{- end }}
+{{- end }}

--- a/charts/faceapi/templates/role.yaml
+++ b/charts/faceapi/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) -}}
+{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) .Values.serviceAccount.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/faceapi/templates/role.yaml
+++ b/charts/faceapi/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) .Values.serviceAccount.create -}}
+{{- if and .Values.rbac.create (not .Values.rbac.useExistingRole) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/faceapi/templates/rolebinding.yaml
+++ b/charts/faceapi/templates/rolebinding.yaml
@@ -19,5 +19,5 @@ roleRef:
   {{- end }}
 subjects:
 - kind: ServiceAccount
-  name: {{ default "faceapi" .Values.serviceAccount.name }}
+  name: {{ include "faceapi.serviceAccount" . }}
 {{- end }}

--- a/charts/faceapi/templates/rolebinding.yaml
+++ b/charts/faceapi/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.serviceAccount.create }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/faceapi/templates/rolebinding.yaml
+++ b/charts/faceapi/templates/rolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "faceapi.fullname" . }}
+  labels:
+    {{- include "faceapi.labels" . | nindent 4 }}
+  {{- with .Values.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  {{- if .Values.rbac.useExistingRole }}
+  name: {{ .Values.rbac.useExistingRole }}
+  {{- else }}
+  name: {{ include "faceapi.fullname" . }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: {{ default "faceapi" .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/faceapi/templates/rolebinding.yaml
+++ b/charts/faceapi/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.serviceAccount.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/faceapi/templates/serviceaccount.yaml
+++ b/charts/faceapi/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default (include "faceapi.fullname" .) .Values.serviceAccount.name }}
+  name: {{ default "faceapi" .Values.serviceAccount.name }}
   labels: {{- include "faceapi.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/faceapi/templates/serviceaccount.yaml
+++ b/charts/faceapi/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ default "faceapi" .Values.serviceAccount.name }}
+  name: {{ include "faceapi.serviceAccount" . }}
   labels: {{- include "faceapi.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/faceapi/values.yaml
+++ b/charts/faceapi/values.yaml
@@ -386,14 +386,14 @@ networkPolicy:
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # The name of the service account to use.
   name: ~
   # Annotations to add to the service account
   annotations: {}
 
 rbac:
-  create: true
+  create: false
   annotations: {}
   # Use an existing Role
   # useExistingRole: name-of-some-role

--- a/charts/faceapi/values.yaml
+++ b/charts/faceapi/values.yaml
@@ -364,10 +364,7 @@ networkPolicy:
   #   matchExpressions:
   #    - {key: role, operator: In, values: [frontend]}
   #
-  # Allow traffic from kube-system namespace (ingress controller)
-  explicitNamespacesSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: kube-system
+  explicitNamespacesSelector: {}
   #
   egress:
     # networkPolicy.egress.enabled: When enabled, an egress network policy will be

--- a/charts/faceapi/values.yaml
+++ b/charts/faceapi/values.yaml
@@ -341,13 +341,69 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+networkPolicy:
+  # networkPolicy.enabled: Enable creation of NetworkPolicy resources.
+  enabled: true
+  # networkPolicy.annotations: Add annotations to network policy.
+  annotations: {}
+  # networkPolicy.ingress: When true enables the creation of ingress network policy.
+  ingress: true
+  # networkPolicy.allowExternal: When set to false, only pods with the correct '-client' label within faceapi namespace will have network access to faceapi port defined.
+  # When true, faceapi will accept connections from any source (with the correct destination port).
+  allowExternal: false
+  # networkPolicy.explicitNamespacesSelector: A Kubernetes LabelSelector to explicitly select namespaces
+  # from which traffic could be allowed. If explicitNamespacesSelector is missing or set to {},
+  # only client Pods that are in the networkPolicy's namespace and that match other criteria, the ones that have the good label, can reach the faceapi.
+  # But sometimes, we want the faceapi to be accessible to clients from other namespaces, in this case, we can use this
+  # LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  #
+  # Example:
+  # explicitNamespacesSelector:
+  #   matchLabels:
+  #     role: frontend
+  #   matchExpressions:
+  #    - {key: role, operator: In, values: [frontend]}
+  #
+  # Allow traffic from kube-system namespace (ingress controller)
+  explicitNamespacesSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: kube-system
+  #
+  egress:
+    # networkPolicy.egress.enabled: When enabled, an egress network policy will be
+    # created allowing faceapi to connect to external data sources from kubernetes cluster.
+    enabled: false
+    # networkPolicy.egress.blockDNSResolution: When enabled, DNS resolution will be blocked
+    # for all pods in the faceapi namespace.
+    blockDNSResolution: false
+    # networkPolicy.egress.ports: Add individual ports to be allowed by the egress
+    # Add ports to the egress by specifying - port: <port number>
+    # Example
+    # - port: 80
+    # - port: 443
+    #
+    ports: []
+    # networkPolicy.egress.to: Allow egress traffic to specific destinations
+    to: []
+    #
+
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # The name of the service account to use.
   name: ~
   # Annotations to add to the service account
   annotations: {}
+
+rbac:
+  create: true
+  annotations: {}
+  # Use an existing Role
+  # useExistingRole: name-of-some-role
+  extraRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   verbs: []
 
 serviceMonitor:
   # Set this to `true` to create ServiceMonitor for Prometheus operator

--- a/charts/faceapi/values.yaml
+++ b/charts/faceapi/values.yaml
@@ -342,52 +342,40 @@ ingress:
   #      - chart-example.local
 
 networkPolicy:
-  # networkPolicy.enabled: Enable creation of NetworkPolicy resources.
-  enabled: true
-  # networkPolicy.annotations: Add annotations to network policy.
+  enabled: false
   annotations: {}
-  # networkPolicy.ingress: When true enables the creation of ingress network policy.
-  ingress: true
-  # networkPolicy.allowExternal: When set to false, only pods with the correct '-client' label within faceapi namespace will have network access to faceapi port defined.
-  # When true, faceapi will accept connections from any source (with the correct destination port).
-  allowExternal: false
-  # networkPolicy.explicitNamespacesSelector: A Kubernetes LabelSelector to explicitly select namespaces
-  # from which traffic could be allowed. If explicitNamespacesSelector is missing or set to {},
-  # only client Pods that are in the networkPolicy's namespace and that match other criteria, the ones that have the good label, can reach the faceapi.
-  # But sometimes, we want the faceapi to be accessible to clients from other namespaces, in this case, we can use this
-  # LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
-  #
-  # Example:
-  # explicitNamespacesSelector:
-  #   matchLabels:
-  #     role: frontend
-  #   matchExpressions:
-  #    - {key: role, operator: In, values: [frontend]}
-  #
-  explicitNamespacesSelector: {}
-  #
-  egress:
-    # networkPolicy.egress.enabled: When enabled, an egress network policy will be
-    # created allowing faceapi to connect to external data sources from kubernetes cluster.
-    enabled: false
-    # networkPolicy.egress.blockDNSResolution: When enabled, DNS resolution will be blocked
-    # for all pods in the faceapi namespace.
-    blockDNSResolution: false
-    # networkPolicy.egress.ports: Add individual ports to be allowed by the egress
-    # Add ports to the egress by specifying - port: <port number>
-    # Example
-    # - port: 80
-    # - port: 443
-    #
-    ports: []
-    # networkPolicy.egress.to: Allow egress traffic to specific destinations
-    to: []
-    #
+  ingress: {}
+    # # allow ingress traffic from local namespace only
+    # - from:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         kubernetes.io/metadata.name: put-your-namespace-here
+  egress: {}
+    # # allow egress traffic to local namespace only
+    # - to:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         kubernetes.io/metadata.name: put-your-namespace-here
+    # # allow DNS resolution
+    # - ports:
+    #   - protocol: UDP
+    #     port: 53
+    # # allow traffic to lic.regulaforensics.com and lic2.regulaforensics.com
+    # - ports:
+    #   - protocol: TCP
+    #     port: 443
+    #   to:
+    #     - ipBlock:
+    #         cidr: 3.33.212.24/32
+    #     - ipBlock:
+    #         cidr: 15.197.254.180/32
+    #     - ipBlock:
+    #         cidr: 34.96.77.73/32
 
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
-  # The name of the service account to use.
+  # The name of service account to create.
   name: ~
   # Annotations to add to the service account
   annotations: {}


### PR DESCRIPTION
### Task id
[SP-15856](https://app.clickup.com/t/4535044/SP-15856)

### Summary
Currently there is no segregation between different installations of a single service except namespaces. Services are not strictly scoped to their namespaces. This PR adds the possibility to define network policy and role for dedicated service account.

### What's done

#### Docreader
1. Add service account and bind role to it with role binding. By default role doesn't contain any permissions.
2. Add network policy which by default restricts any traffic to service outside of its namespace.

#### Faceapi
1. Add service account and bind role to it with role binding. By default role doesn't contain any permissions.
2. Add network policy which by default restricts any traffic to service outside of its namespace.

#### Workflows
Add semver-compare workflow which checks if Chart version was increased after changes in Chart itself.