### PR TITLE
Switch to private Helm charts repo

### DIFF
--- a/.github/workflows/release-private-charts.yml
+++ b/.github/workflows/release-private-charts.yml
@@ -1,0 +1,52 @@
+name: Release Private Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  HELM_REPO_URL: https://raw.githubusercontent.com/regulaforensics/helm-test/refs/heads/helm-chart-releases/helm-releases
+  RELEASE_BRANCH: helm-chart-releases
+
+jobs:
+  release-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Package Helm Charts
+        run: |
+          mkdir -p helm-releases
+          helm package charts/* -d helm-releases
+
+      - name: Update Helm Repo Index
+        run: |
+          curl -sf $HELM_REPO_URL/index.yaml -o helm-releases/index.yaml || echo "No existing index found, creating a new one"
+          helm repo index helm-releases/ --merge helm-releases/index.yaml --url $HELM_REPO_URL
+
+      - name: Commit and Push Changes
+        run: |
+          git stash --include-untracked
+          git fetch origin $RELEASE_BRANCH
+          git checkout $RELEASE_BRANCH
+          rm -rf helm-releases/index.yaml
+          git stash pop || echo "Some files were not stashed"
+          git add helm-releases/*
+          git commit -m "Updated Helm charts from ref: $GITHUB_SHA"
+          git push origin $RELEASE_BRANCH

--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 Once Helm is set up properly, add the repo as follows:
 
 ```
-helm repo add regulaforensics https://regulaforensics.github.io/helm-charts
+helm repo add regula-test https://raw.githubusercontent.com/regulaforensics/helm-test/refs/heads/helm-chart-releases/helm-releases/
 helm repo update
 ```
 
-You can then run `helm search repo regulaforensics` to see the charts.
+You can then run `helm search repo regula-test` to see the charts.
 
-- [Docreader](https://github.com/regulaforensics/helm-charts/tree/main/charts/docreader)
-- [FaceAPI](https://github.com/regulaforensics/helm-charts/tree/main/charts/faceapi)
+- [Docreader](https://github.com/regulaforensics/helm-test/tree/main/charts/docreader)
+- [FaceAPI](https://github.com/regulaforensics/helm-test/tree/main/charts/faceapi)
+- [afis-api](https://github.com/regulaforensics/helm-test/tree/main/charts/afis-api)
+- [api-gateway](https://github.com/regulaforensics/helm-test/tree/main/charts/api-gateway)
 
 <!-- Keep full URL links to repo files because this README syncs from main to gh-pages.  -->
 Chart documentation is available at [docs.regulaforensics.com](https://docs.regulaforensics.com).

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 Once Helm is set up properly, add the repo as follows:
 
 ```
-helm repo add regula-test https://raw.githubusercontent.com/regulaforensics/helm-test/refs/heads/helm-chart-releases/helm-releases/
+helm repo add regulaforensics https://raw.githubusercontent.com/regulaforensics/helm-test/refs/heads/helm-chart-releases/helm-releases/
 helm repo update
 ```
 
-You can then run `helm search repo regula-test` to see the charts.
+You can then run `helm search repo regulaforensics` to see the charts.
 
 - [Docreader](https://github.com/regulaforensics/helm-test/tree/main/charts/docreader)
 - [FaceAPI](https://github.com/regulaforensics/helm-test/tree/main/charts/faceapi)


### PR DESCRIPTION
## General Info

This PR introduces a new workflow for publishing Helm charts to a dedicated branch. This workflow will be utilized after the repository is switched to private mode, ensuring a streamlined and secure chart publishing process.