### PR TITLE
Remove secrets and change service account for statsd

### DIFF
--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 0.1.5
+version: 0.1.6
 appVersion: "2.3.5"
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/idv/templates/config.tpl
+++ b/charts/idv/templates/config.tpl
@@ -83,11 +83,6 @@ metrics:
     port: 9125
     prefix: {{ quote .Values.config.metrics.statsd.prefix }}
     {{- end }}
-  database:
-    enabled: {{ .Values.config.metrics.database.enabled }}
-    {{- if .Values.config.metrics.database.enabled }}
-    expireAfterSeconds: {{ .Values.config.metrics.database.expireAfterSeconds }}
-    {{- end }}
   alerts:
     enabled: {{ .Values.config.metrics.alerts.enabled }}
     {{- if .Values.config.metrics.alerts.enabled }}

--- a/charts/idv/templates/deployment-statsd.yaml
+++ b/charts/idv/templates/deployment-statsd.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "idv.labels" . | nindent 8 }}
         component: statsd
     spec:
-      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      serviceAccountName: default
       {{- with .Values.statsd.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -86,7 +86,6 @@ spec:
         {{- with .Values.statsd.ports }}
         ports: {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
-        env: {{- tpl (toYaml .Values.env) . | nindent 10 }}
         volumeMounts:
           - name: config
             mountPath: /etc/statsd-exporter/mappings.yml

--- a/charts/idv/values.yaml
+++ b/charts/idv/values.yaml
@@ -182,9 +182,6 @@ config:
     statsd:
       enabled: true
       prefix: idv
-    database:
-      enabled: true
-      expireAfterSeconds: 15552000
     alerts:
       enabled: false
       source: prometheus


### PR DESCRIPTION
## Description
- Remove mounting of secret values to `statsd` as they are unnecessary for this service
- Updated service account to `default` for `statsd` in alignment with the principle of least privilege