### PR TITLE
Add extra volumes and mounts for db-migration job

### DIFF
--- a/charts/docreader/templates/db-migration-job.yaml
+++ b/charts/docreader/templates/db-migration-job.yaml
@@ -65,8 +65,14 @@ spec:
               mountPath: /app/config.yaml
               subPath: config.yaml
               readOnly: true
+          {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       volumes:
         - name: docreader-config
           configMap:
             name: {{ include "docreader.config.name" . }}
+      {{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/faceapi/templates/db-migration-job.yaml
+++ b/charts/faceapi/templates/db-migration-job.yaml
@@ -65,8 +65,14 @@ spec:
               mountPath: /app/config.yaml
               subPath: config.yaml
               readOnly: true
+          {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
       volumes:
         - name: faceapi-config
           configMap:
             name: {{ include "faceapi.config.name" . }}
+      {{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
Add possibility to add `extraVolumes` and `extraVolumeMounts` for **db-migration-job**.